### PR TITLE
Add further tests for include version in history

### DIFF
--- a/test/expected/noop_update.out
+++ b/test/expected/noop_update.out
@@ -1,0 +1,21 @@
+-- No-op Update Test
+CREATE TABLE versioning_noop (a bigint, "b b" date, sys_period tstzrange);
+-- Insert initial data.
+INSERT INTO versioning_noop (a, "b b", sys_period) VALUES (1, '2020-01-01', tstzrange('2000-01-01', NULL));
+CREATE TABLE versioning_noop_history (a bigint, "b b" date, sys_period tstzrange);
+CREATE TRIGGER versioning_noop_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON versioning_noop
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_noop_history', false, true, true);
+-- Test no-op update (the row is updated without any value changes).
+BEGIN;
+UPDATE versioning_noop SET a = 1, "b b" = '2020-01-01' WHERE a = 1;
+-- Check that no history record was created.
+SELECT * FROM versioning_noop_history;  -- Expecting 0 rows in history.
+ a | b b | sys_period 
+---+-----+------------
+(0 rows)
+
+COMMIT;
+-- Cleanup
+DROP TABLE versioning_noop;
+DROP TABLE versioning_noop_history;

--- a/test/expected/versioning_rollback_include_current_version_in_history.out
+++ b/test/expected/versioning_rollback_include_current_version_in_history.out
@@ -1,0 +1,29 @@
+-- Rollback Behavior Test
+CREATE TABLE versioning_rollback (a bigint, "b b" date, sys_period tstzrange);
+-- Insert initial data.
+INSERT INTO versioning_rollback (a, "b b", sys_period) VALUES (1, '2020-01-01', tstzrange('2000-01-01', NULL));
+CREATE TABLE versioning_rollback_history (a bigint, "b b" date, sys_period tstzrange);
+CREATE TRIGGER versioning_rollback_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON versioning_rollback
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_rollback_history', false, false, true);
+-- Test rollback during update.
+BEGIN;
+UPDATE versioning_rollback SET a = 2 WHERE a = 1;
+-- Rollback the transaction.
+ROLLBACK;
+-- Ensure no history record was created.
+SELECT * FROM versioning_rollback_history;  -- Expecting 0 rows in history.
+ a | b b | sys_period 
+---+-----+------------
+(0 rows)
+
+-- Ensure original data is unchanged.
+SELECT * FROM versioning_rollback;  -- Expecting original value a = 1.
+ a |    b b     |         sys_period          
+---+------------+-----------------------------
+ 1 | 2020-01-01 | ["2000-01-01 00:00:00+00",)
+(1 row)
+
+-- Cleanup
+DROP TABLE versioning_rollback;
+DROP TABLE versioning_rollback_history;

--- a/test/runTest.sh
+++ b/test/runTest.sh
@@ -13,6 +13,7 @@ TESTS="
   different_schema unchanged_values unchanged_version_values
   non_equality_types non_equality_types_unchanged_values
   set_system_time invalid_set_system_time versioning_including_current_version_in_history
+  versioning_rollback_include_current_version_in_history noop_update
   "
 
 for name in $TESTS; do

--- a/test/sql/noop_update.sql
+++ b/test/sql/noop_update.sql
@@ -1,0 +1,25 @@
+-- No-op Update Test
+CREATE TABLE versioning_noop (a bigint, "b b" date, sys_period tstzrange);
+
+-- Insert initial data.
+INSERT INTO versioning_noop (a, "b b", sys_period) VALUES (1, '2020-01-01', tstzrange('2000-01-01', NULL));
+
+CREATE TABLE versioning_noop_history (a bigint, "b b" date, sys_period tstzrange);
+
+CREATE TRIGGER versioning_noop_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON versioning_noop
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_noop_history', false, true, true);
+
+-- Test no-op update (the row is updated without any value changes).
+BEGIN;
+
+UPDATE versioning_noop SET a = 1, "b b" = '2020-01-01' WHERE a = 1;
+
+-- Check that no history record was created.
+SELECT * FROM versioning_noop_history;  -- Expecting 0 rows in history.
+
+COMMIT;
+
+-- Cleanup
+DROP TABLE versioning_noop;
+DROP TABLE versioning_noop_history;

--- a/test/sql/versioning_rollback_include_current_version_in_history.sql
+++ b/test/sql/versioning_rollback_include_current_version_in_history.sql
@@ -1,0 +1,29 @@
+-- Rollback Behavior Test
+CREATE TABLE versioning_rollback (a bigint, "b b" date, sys_period tstzrange);
+
+-- Insert initial data.
+INSERT INTO versioning_rollback (a, "b b", sys_period) VALUES (1, '2020-01-01', tstzrange('2000-01-01', NULL));
+
+CREATE TABLE versioning_rollback_history (a bigint, "b b" date, sys_period tstzrange);
+
+CREATE TRIGGER versioning_rollback_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON versioning_rollback
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_rollback_history', false, false, true);
+
+-- Test rollback during update.
+BEGIN;
+
+UPDATE versioning_rollback SET a = 2 WHERE a = 1;
+
+-- Rollback the transaction.
+ROLLBACK;
+
+-- Ensure no history record was created.
+SELECT * FROM versioning_rollback_history;  -- Expecting 0 rows in history.
+
+-- Ensure original data is unchanged.
+SELECT * FROM versioning_rollback;  -- Expecting original value a = 1.
+
+-- Cleanup
+DROP TABLE versioning_rollback;
+DROP TABLE versioning_rollback_history;


### PR DESCRIPTION
Added 2 more tests to cover no-op updates and potential rollbacks.
Merge if needed.